### PR TITLE
Fix unresolved import for DefaultHasher

### DIFF
--- a/src/bin/cuda_dummy_test.rs
+++ b/src/bin/cuda_dummy_test.rs
@@ -96,7 +96,8 @@ fn main() {
         args.num_blocks, input_layout
     );
 
-    use std::hash::{DefaultHasher, Hash, Hasher};
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hasher, Hash};
     let mut s = DefaultHasher::new();
     script.blocks_data.hash(&mut s);
     println!("Script hash: {}", s.finish());

--- a/src/bin/cuda_test.rs
+++ b/src/bin/cuda_test.rs
@@ -464,7 +464,8 @@ fn main() {
         args.num_blocks, input_layout
     );
 
-    use std::hash::{DefaultHasher, Hasher};
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::Hasher;
     let mut s = DefaultHasher::new();
     script.blocks_data.hash(&mut s);
     println!("Script hash: {}", s.finish());

--- a/src/bin/flatten_test.rs
+++ b/src/bin/flatten_test.rs
@@ -57,7 +57,7 @@ struct SimulatorArgs {
 }
 
 fn hash_of<T: Hash>(x: &T) -> u64 {
-    let mut hasher = std::hash::DefaultHasher::new();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
     x.hash(&mut hasher);
     hasher.finish()
 }


### PR DESCRIPTION
Recent Rust move `std::hash::DefaultHasher` to `std::collections::hash_map::DefaultHasher`. This PR fixes import error mentioned in #3 