### PR TITLE
fix: cluster loop excludes the last AIG pin index

### DIFF
--- a/src/repcut.rs
+++ b/src/repcut.rs
@@ -113,7 +113,7 @@ impl RCHyperGraph {
         });
         // println!("sbn: {:?}", segments_blockid_nodeid);
         let mut clusters = IndexMap::<_, usize>::new();
-        for i in 1..aig.num_aigpins {
+        for i in 1..=aig.num_aigpins {
             let es = CachedHash::new(EndpointSet {
                 s: (0..num_blocks)
                     .map(|k| segments_blockid_nodeid[k][i]


### PR DESCRIPTION
### Problem
fix: cluster loop excludes the last AIG pin index

### Fix
Replace:
```
        for i in 1..aig.num_aigpins {
            let es = CachedHash::new(EndpointSet {
                s: (0..num_blocks)
                    .map(|k| segments_blockid_nodeid[k][i]
                         .clone()).collect()
            });
            if es.popcount() >= 2 {
                *clusters.entry(es).or_default() += 1;
            }
        }
```

with:
```
        for i in 1..=aig.num_aigpins {
            let es = CachedHash::new(EndpointSet {
                s: (0..num_blocks)
                    .map(|k| segments_blockid_nodeid[k][i]
                         .clone()).collect()
            });
            if es.popcount() >= 2 {
                *clusters.entry(es).or_default() += 1;
            }
        }
```

### Files changed
- `src/repcut.rs`